### PR TITLE
Rename of the packaged jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>gumi</groupId>
-    <artifactId>builders</artifactId>
+    <artifactId>mikaelhg-urlbuilder</artifactId>
     <version>1.2</version>
 
     <licenses>


### PR DESCRIPTION
Hi Mikael, great little library! I'm looking to include this in a web project I'm prepping for github. The generated jar file is called 'builders', which makes it difficult to trace it back to your original project. On my fork I've renamed it to 'mikaelhg-urlbuilder'. Cheers, S
