### PR TITLE
Let Maven generate OSGi manifest information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>mikaelhg</groupId>
     <artifactId>urlbuilder</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -70,6 +70,37 @@
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.6</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>  
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive> 
+                </configuration>
+           </plugin>  
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.3</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                   </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>gumi.builders.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
I've added the maven bundle plugin in order to have Maven generate a valid OSGi bundle manifest.