### PR TITLE
Avoid exceptions from percent encodings that appear at the end of URL

### DIFF
--- a/src/main/java/gumi/builders/url/Decoder.java
+++ b/src/main/java/gumi/builders/url/Decoder.java
@@ -77,7 +77,7 @@ public class Decoder {
         int j = 0;
         for (int i = position; i < len; i++) {
             final char c0 = input.charAt(i);
-            if (c0 != '%' || (len < i + 2)) {
+            if (c0 != '%' || (len < i + 3)) {
                 return Arrays.copyOfRange(data, 0, j);
             } else {
                 data[j++] = (byte) Integer.parseInt(input.substring(i + 1, i + 3), 16);
@@ -116,9 +116,11 @@ public class Decoder {
                 sb.append(' ');
             } else if (c0 != '%') {
                 sb.append(c0);
-            } else if (len < i + 2) {
+            } else if (len < i + 3) {
                 // the string will end before we will be able to read a sequence
-                i += 2;
+	            int endIndex = Math.min(input.length(), i+2);
+	            sb.append(input.substring(i, endIndex));
+                i += 3;
             } else {
                 final byte[] bytes = nextDecodeableSequence(input, i);
                 sb.append(inputEncoding.decode(ByteBuffer.wrap(bytes)));

--- a/src/test/java/gumi/builders/SimpleUrlTest.java
+++ b/src/test/java/gumi/builders/SimpleUrlTest.java
@@ -92,6 +92,19 @@ public class SimpleUrlTest {
         assertEquals(portUrl, UrlBuilder.fromString(portUrl).toString());
     }
 
+	@Test
+	public void percentEndOfLineTest() throws Exception {
+		final UrlBuilder ub1 = UrlBuilder.fromString("http://www.example.com/?q=Science%2");
+		final UrlBuilder ub2 = UrlBuilder.fromString("http://www.example.com/?q=Science%25");
+		final UrlBuilder ub3 = UrlBuilder.fromString("http://www.example.com/?q=Science%");
+		final UrlBuilder ub4 = UrlBuilder.fromString("http://www.example.com/?q=Science%255");
+
+		assertEquals(ub1.toString(), "http://www.example.com/?q=Science%252");
+		assertEquals(ub2.toString(), "http://www.example.com/?q=Science%25");
+		assertEquals(ub3.toString(), "http://www.example.com/?q=Science%25");
+		assertEquals(ub4.toString(), "http://www.example.com/?q=Science%255");
+	}
+
     @Test
     public void urlExceptionTest() throws Exception {
         UrlBuilder.fromString("https://www:1234/").toUriWithException();


### PR DESCRIPTION
For your consideration, some URLs that had malformed percent encodings at the end of the URL were throwing exceptions.  Instead of throwing an exception in these cases the URL is created. 